### PR TITLE
Add trackers removed to main data dto

### DIFF
--- a/lib/src/v2/sync/dto/main_data.dart
+++ b/lib/src/v2/sync/dto/main_data.dart
@@ -18,6 +18,7 @@ class MainData {
     this.tagsRemoved,
     this.serverState,
     this.trackers,
+    this.trackersRemoved,
   });
 
   factory MainData.fromJson(Map<String, dynamic> json) =>
@@ -61,6 +62,9 @@ class MainData {
 
   @JsonKey(name: 'trackers')
   final Map<String, List<String>>? trackers;
+
+  @JsonKey(name: 'trackers_removed')
+  final List<String>? trackersRemoved;
 
   Map<String, dynamic> toJson() => _$MainDataToJson(this);
 }

--- a/lib/src/v2/sync/dto/main_data.g.dart
+++ b/lib/src/v2/sync/dto/main_data.g.dart
@@ -32,6 +32,9 @@ MainData _$MainDataFromJson(Map<String, dynamic> json) => MainData(
         (k, e) =>
             MapEntry(k, (e as List<dynamic>).map((e) => e as String).toList()),
       ),
+      trackersRemoved: (json['trackers_removed'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
     );
 
 Map<String, dynamic> _$MainDataToJson(MainData instance) {
@@ -53,5 +56,6 @@ Map<String, dynamic> _$MainDataToJson(MainData instance) {
   writeNotNull('tags_removed', instance.tagsRemoved);
   writeNotNull('server_state', instance.serverState);
   writeNotNull('trackers', instance.trackers);
+  writeNotNull('trackers_removed', instance.trackersRemoved);
   return val;
 }


### PR DESCRIPTION
The qBittorrent API sends a `"trackers_removed"` array in the response to a `sync/maindata` request, as suggested in the [documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-main-data). This change adds that field to the `MainData` dto.