### PR TITLE
Add peers removed to peers data dto

### DIFF
--- a/lib/src/v2/sync/dto/peers_data.dart
+++ b/lib/src/v2/sync/dto/peers_data.dart
@@ -8,6 +8,7 @@ class PeersData {
   const PeersData({
     this.fullUpdate,
     this.peers,
+    this.peersRemoved,
     this.rid,
     this.showFlags,
   });
@@ -20,6 +21,9 @@ class PeersData {
 
   @JsonKey(name: 'peers')
   final Map<String, PeersInfo>? peers;
+
+  @JsonKey(name: 'peers_removed')
+  final List<String>? peersRemoved;
 
   @JsonKey(name: 'rid')
   final int? rid;

--- a/lib/src/v2/sync/dto/peers_data.g.dart
+++ b/lib/src/v2/sync/dto/peers_data.g.dart
@@ -11,6 +11,9 @@ PeersData _$PeersDataFromJson(Map<String, dynamic> json) => PeersData(
       peers: (json['peers'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, PeersInfo.fromJson(e as Map<String, dynamic>)),
       ),
+      peersRemoved: (json['peers_removed'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
       rid: json['rid'] as int?,
       showFlags: json['show_flags'] as bool?,
     );
@@ -26,6 +29,7 @@ Map<String, dynamic> _$PeersDataToJson(PeersData instance) {
 
   writeNotNull('full_update', instance.fullUpdate);
   writeNotNull('peers', instance.peers);
+  writeNotNull('peers_removed', instance.peersRemoved);
   writeNotNull('rid', instance.rid);
   writeNotNull('show_flags', instance.showFlags);
   return val;


### PR DESCRIPTION
The qBittorrent API sends a `"peers_removed"` array in the response to a `sync/torrentPeers` request. While it is not referenced in the [documentation](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-torrent-peers-data), you can see it being referenced in the [WebUI source code](https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/www/private/scripts/prop-peers.js#L88). This change adds that field to the `PeersData` dto.