### PR TITLE
Fix: Change relevance to double on peers info dto

### DIFF
--- a/lib/src/v2/sync/dto/peers_info.dart
+++ b/lib/src/v2/sync/dto/peers_info.dart
@@ -66,7 +66,7 @@ class PeersInfo {
   final double? progress;
 
   @JsonKey(name: 'relevance')
-  final int? relevance;
+  final double? relevance;
 
   @JsonKey(name: 'up_speed')
   final int? upSpeed;

--- a/lib/src/v2/sync/dto/peers_info.g.dart
+++ b/lib/src/v2/sync/dto/peers_info.g.dart
@@ -20,7 +20,7 @@ PeersInfo _$PeersInfoFromJson(Map<String, dynamic> json) => PeersInfo(
       peerIdClient: json['peer_id_client'] as String?,
       port: json['port'] as int?,
       progress: (json['progress'] as num?)?.toDouble(),
-      relevance: json['relevance'] as int?,
+      relevance: (json['relevance'] as num?)?.toDouble(),
       upSpeed: json['up_speed'] as int?,
       uploaded: json['uploaded'] as int?,
     );


### PR DESCRIPTION
I got an exception calling `subscribeTorrentPeersData` on the `SyncController`. The client has the `PeerInfo.relevance` datatype as an `int?`, but the API appears to be sending a `double`. While the documentation doesn't appear to have any information for this response object, I see that the WebUI renders the "relevance" column in the "peers" tab as a percent, suggesting that the API is responding with a value between 0 and 1.

This change updates the datatype to be `double?` rather than `int?`.

This is the stacktrace I received:
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: type 'double' is not a subtype of type 'int?' in type cast
#0      _$PeersInfoFromJson (package:qbittorrent_api/src/v2/sync/dto/peers_info.g.dart:23:36)
#1      new PeersInfo.fromJson (package:qbittorrent_api/src/v2/sync/dto/peers_info.dart:27:7)
#2      _$PeersDataFromJson.<anonymous closure> (package:qbittorrent_api/src/v2/sync/dto/peers_data.g.dart:12:41)
...
```