### PR TITLE
Added auto login cookie setter for improved security

### DIFF
--- a/lib/src/network/api_client.dart
+++ b/lib/src/network/api_client.dart
@@ -15,6 +15,7 @@ abstract interface class ApiClient {
     Map<String, String>? headers,
     Map<String, dynamic>? formData,
     bool returnBytes,
+    bool setCookies,
   });
 
   Future<void> clearCookies();

--- a/lib/src/network/dio_client.dart
+++ b/lib/src/network/dio_client.dart
@@ -83,6 +83,7 @@ class DioClient implements ApiClient {
     Map<String, String>? headers,
     Map<String, dynamic>? formData,
     bool returnBytes = false,
+    bool setCookies = false,
   }) async {
     final dynamic requestData;
     if (formData != null) {
@@ -130,6 +131,24 @@ class DioClient implements ApiClient {
           responseType: returnBytes ? ResponseType.bytes : ResponseType.plain,
         ),
       );
+
+      if (setCookies) {
+        final setCookieHeaders = response.headers['set-cookie'];
+        if (setCookieHeaders != null) {
+          _dio.interceptors.removeWhere((i) => i is InterceptorsWrapper && i.runtimeType.toString().contains('CookieInterceptor'));
+          for (final header in setCookieHeaders) {
+            _dio.interceptors.add(
+              InterceptorsWrapper(
+                onRequest: (options, handler) {
+                  options.headers['Cookie'] = header;
+                  return handler.next(options);
+                },
+              ),
+            );
+          }
+        }
+      }
+
       return _convertDataFormat(response);
     });
   }

--- a/lib/src/network/dio_client.dart
+++ b/lib/src/network/dio_client.dart
@@ -132,7 +132,7 @@ class DioClient implements ApiClient {
         ),
       );
 
-      if (setCookies) {
+      if (setCookies && cookiePath == null) {
         final setCookieHeaders = response.headers['set-cookie'];
         if (setCookieHeaders != null) {
           _dio.interceptors.removeWhere((i) => i is InterceptorsWrapper && i.runtimeType.toString().contains('CookieInterceptor'));

--- a/lib/src/v2/auth/auth_controller.dart
+++ b/lib/src/v2/auth/auth_controller.dart
@@ -23,6 +23,7 @@ class AuthController {
         'username': username,
         'password': password,
       },
+      setCookies: true,
     );
 
     // Throw unauthorized exception here as qBittorrent returns status code 200

--- a/test/network/fake_api_client.dart
+++ b/test/network/fake_api_client.dart
@@ -36,6 +36,7 @@ class FakeApiClient implements ApiClient {
     Map<String, String>? headers,
     Map<String, dynamic>? formData,
     bool returnBytes = false,
+    bool setCookies = false,
   }) async {
     _path = path;
     _params = params;


### PR DESCRIPTION
Hello, in order to add more security to the this plugin (Especially for Mobile Development) I've made changes in order to set the login cookie automatically instead of giving a file path. 

The .cookie file could be retrieved on the device and be read and used as is. Now, with the auto cookie setter no file is stored on the device. Feel free to edit or recommend better approach if you want